### PR TITLE
remove homepage property

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "runes",
   "version": "0.1.0",
   "private": true,
-  "homepage": "runestudy.com",
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",


### PR DESCRIPTION
`homepage` controls the subdirectory an app is served at; if not provided, it will assume it is at the root.